### PR TITLE
Import/export: within a session, open the file dialog in the same location as last time

### DIFF
--- a/src/main/java/interface_adapters/tui/controllers/RecipeTransferOperation.java
+++ b/src/main/java/interface_adapters/tui/controllers/RecipeTransferOperation.java
@@ -20,6 +20,8 @@ public class RecipeTransferOperation implements TextualOperation {
     private final RecipeDataConverter converter;
     private final RecipeManager recipeManager;
 
+    private final JFileChooser fileChooser = new JFileChooser();
+
     private final List<TextualOperation> operations = List.of(
             new RecipeImporter(),
             new RecipeExporter()
@@ -68,12 +70,11 @@ public class RecipeTransferOperation implements TextualOperation {
 
             System.out.println("Choose the location to save the exported file.");
             Colour.info("Note: the file dialog may have opened behind other windows.");
-            JFileChooser fc = new JFileChooser();
             forceDialogFocus();
-            if (fc.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) {
+            if (fileChooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) {
                 return;
             }
-            File file = fc.getSelectedFile();
+            File file = fileChooser.getSelectedFile();
 
             if (file.exists()) {
                 Colour.info("%s already exists, overwrite?", file.getName());
@@ -113,12 +114,11 @@ public class RecipeTransferOperation implements TextualOperation {
         public void run() {
             System.out.println("Choose the file to import from.");
             Colour.info("Note: the file dialog may have opened behind other windows.");
-            JFileChooser fc = new JFileChooser();
             forceDialogFocus();
-            if (fc.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) {
+            if (fileChooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) {
                 return;
             }
-            File file = fc.getSelectedFile();
+            File file = fileChooser.getSelectedFile();
 
             RecipeData recipeData;
             try {


### PR DESCRIPTION
To improve the ergonomics of my use case a bit. I noticed the following from [the Java documentation](https://docs.oracle.com/javase/tutorial/uiswing/components/filechooser.html):

> By default, a file chooser that has not been shown before displays all files in the user's home directory. You can specify the file chooser's initial directory by using one of JFileChooser's other constructors, or you can set the directory with the setCurrentDirectory method.

At this point in time, a few hours before the presentation, specifying an initial directory based on previous sessions would require too much time and research from me. However, making stuff work nicely _within_ a session was significantly less effort: simply create _one_ JFileChooser for the lifetime of the entire program. While we're still waiting for some of the other UIs to finish, this is a small enhancement that can make things a bit easier on the user.