### PR TITLE
Fix IntelliJ Warnings

### DIFF
--- a/src/main/java/database/Database.java
+++ b/src/main/java/database/Database.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
  * An abstract class which handles storing DAOs (Database Access Objects).
  */
 public abstract class Database {
+    @SuppressWarnings("rawtypes")
     private final HashMap<Class, Dao<?, ?>> daoHashMap = new HashMap<>();
 
     abstract public <D extends Dao<Entity, ?>, Entity> D createDao(Class<Entity> entity) throws SQLException;

--- a/src/main/java/database/Database.java
+++ b/src/main/java/database/Database.java
@@ -9,8 +9,7 @@ import java.util.HashMap;
  * An abstract class which handles storing DAOs (Database Access Objects).
  */
 public abstract class Database {
-    @SuppressWarnings("rawtypes")
-    private final HashMap<Class, Dao<?, ?>> daoHashMap = new HashMap<>();
+    private final HashMap<Class<?>, Dao<?, ?>> daoHashMap = new HashMap<>();
 
     abstract public <D extends Dao<Entity, ?>, Entity> D createDao(Class<Entity> entity) throws SQLException;
 

--- a/src/main/java/entity/Ingredient.java
+++ b/src/main/java/entity/Ingredient.java
@@ -4,6 +4,7 @@ import com.j256.ormlite.field.DatabaseField;
 
 import java.io.Serializable;
 
+@SuppressWarnings("unused")
 public class Ingredient implements Serializable, Preparation {
     /**
      * The name of the ingredient.

--- a/src/main/java/entity/Ingredient.java
+++ b/src/main/java/entity/Ingredient.java
@@ -5,7 +5,7 @@ import com.j256.ormlite.field.DatabaseField;
 import java.io.Serializable;
 
 @SuppressWarnings("unused")
-public class Ingredient implements Serializable, Preparation {
+public class Ingredient implements Serializable, PreparationItem {
     /**
      * The name of the ingredient.
      */

--- a/src/main/java/entity/Note.java
+++ b/src/main/java/entity/Note.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @DatabaseTable(tableName = "notes")
+@SuppressWarnings("unused")
 public class Note implements Serializable {
     /**
      * The ID of the note.

--- a/src/main/java/entity/PreparationItem.java
+++ b/src/main/java/entity/PreparationItem.java
@@ -3,7 +3,7 @@ package entity;
 /**
  * A generic interface for all preparation items.
  */
-public interface Preparation {
+public interface PreparationItem {
     @Override
     boolean equals(Object o);
 }

--- a/src/main/java/entity/Recipe.java
+++ b/src/main/java/entity/Recipe.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 @DatabaseTable(tableName = "recipes")
+@SuppressWarnings("unused")
 public class Recipe implements Serializable {
     /**
      * The ID of the recipe.

--- a/src/main/java/entity/RecipeIngredient.java
+++ b/src/main/java/entity/RecipeIngredient.java
@@ -6,7 +6,8 @@ import com.j256.ormlite.table.DatabaseTable;
 import java.io.Serializable;
 
 @DatabaseTable(tableName = "recipe_ingredients")
-public class RecipeIngredient implements Serializable, RecipePreparation {
+@SuppressWarnings("unused")
+public class RecipeIngredient implements Serializable, RecipePreparationItem {
     @DatabaseField(generatedId = true)
     private int id;
 
@@ -38,7 +39,7 @@ public class RecipeIngredient implements Serializable, RecipePreparation {
     }
 
     @Override
-    public Object getPreparation() {
+    public Ingredient getPreparation() {
         return ingredient;
     }
 

--- a/src/main/java/entity/RecipePreparationItem.java
+++ b/src/main/java/entity/RecipePreparationItem.java
@@ -3,6 +3,6 @@ package entity;
 /**
  * A generic interface for all preparation items with an associated recipe, e.g. <code>RecipeTag</code>.
  */
-public interface RecipePreparation {
-    Object getPreparation();
+public interface RecipePreparationItem {
+    PreparationItem getPreparation();
 }

--- a/src/main/java/entity/RecipeTag.java
+++ b/src/main/java/entity/RecipeTag.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 
 @DatabaseTable(tableName = "recipe_tags")
 @SuppressWarnings("unused")
-public class RecipeTag implements Serializable, RecipePreparation {
+public class RecipeTag implements Serializable, RecipePreparationItem {
     @DatabaseField(generatedId = true)
     private int id;
 
@@ -33,7 +33,7 @@ public class RecipeTag implements Serializable, RecipePreparation {
     }
 
     @Override
-    public Object getPreparation() {
+    public Tag getPreparation() {
         return tag;
     }
 

--- a/src/main/java/entity/RecipeTag.java
+++ b/src/main/java/entity/RecipeTag.java
@@ -6,6 +6,7 @@ import com.j256.ormlite.table.DatabaseTable;
 import java.io.Serializable;
 
 @DatabaseTable(tableName = "recipe_tags")
+@SuppressWarnings("unused")
 public class RecipeTag implements Serializable, RecipePreparation {
     @DatabaseField(generatedId = true)
     private int id;
@@ -21,6 +22,12 @@ public class RecipeTag implements Serializable, RecipePreparation {
         this.tag = tag;
     }
 
+    public RecipeTag(Recipe recipe, Tag tag, int id) {
+        this.recipe = recipe;
+        this.tag = tag;
+        this.id = id;
+    }
+
     public RecipeTag() {
 
     }
@@ -32,5 +39,13 @@ public class RecipeTag implements Serializable, RecipePreparation {
 
     public Tag getTag() {
         return tag;
+    }
+
+    public Recipe getRecipe() {
+        return recipe;
+    }
+
+    public int getID() {
+        return id;
     }
 }

--- a/src/main/java/entity/RecipeTool.java
+++ b/src/main/java/entity/RecipeTool.java
@@ -6,13 +6,13 @@ import com.j256.ormlite.table.DatabaseTable;
 import java.io.Serializable;
 
 @DatabaseTable(tableName = "recipe_tools")
+@SuppressWarnings("unused")
 public class RecipeTool implements Serializable, RecipePreparation {
     @DatabaseField(generatedId = true)
     private int id;
 
     @DatabaseField(foreign = true)
     private Recipe recipe;
-
 
     @DatabaseField(foreign = true)
     private Tool tool;
@@ -22,12 +22,26 @@ public class RecipeTool implements Serializable, RecipePreparation {
         this.tool = tool;
     }
 
+    public RecipeTool(Recipe recipe, Tool tool, int id) {
+        this.recipe = recipe;
+        this.tool = tool;
+        this.id = id;
+    }
+
     public RecipeTool() {
 
     }
 
     public Tool getTool() {
         return tool;
+    }
+
+    public Recipe getRecipe() {
+        return recipe;
+    }
+
+    public int getID() {
+        return id;
     }
 
     @Override

--- a/src/main/java/entity/RecipeTool.java
+++ b/src/main/java/entity/RecipeTool.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 
 @DatabaseTable(tableName = "recipe_tools")
 @SuppressWarnings("unused")
-public class RecipeTool implements Serializable, RecipePreparation {
+public class RecipeTool implements Serializable, RecipePreparationItem {
     @DatabaseField(generatedId = true)
     private int id;
 
@@ -45,7 +45,7 @@ public class RecipeTool implements Serializable, RecipePreparation {
     }
 
     @Override
-    public Object getPreparation() {
+    public Tool getPreparation() {
         return tool;
     }
 }

--- a/src/main/java/entity/Step.java
+++ b/src/main/java/entity/Step.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.util.UUID;
 
 @DatabaseTable(tableName = "steps")
+@SuppressWarnings("unused")
 public class Step implements Serializable {
     /**
      * The ID of the step.

--- a/src/main/java/entity/Tag.java
+++ b/src/main/java/entity/Tag.java
@@ -6,7 +6,8 @@ import com.j256.ormlite.table.DatabaseTable;
 import java.io.Serializable;
 
 @DatabaseTable(tableName = "tags")
-public class Tag implements Serializable, Preparation {
+@SuppressWarnings("unused")
+public class Tag implements Serializable, PreparationItem {
     /**
      * The name of the tag.
      */

--- a/src/main/java/entity/Tool.java
+++ b/src/main/java/entity/Tool.java
@@ -6,7 +6,8 @@ import com.j256.ormlite.table.DatabaseTable;
 import java.io.Serializable;
 
 @DatabaseTable(tableName = "tools")
-public class Tool implements Serializable, Preparation {
+@SuppressWarnings("unused")
+public class Tool implements Serializable, PreparationItem {
     /**
      * The name of the tool.
      */

--- a/src/main/java/interface_adapters/tui/MainController.java
+++ b/src/main/java/interface_adapters/tui/MainController.java
@@ -15,8 +15,8 @@ import java.util.Scanner;
  * The main controller of the textual user interface.
  */
 public class MainController {
-    static Scanner scanner = new Scanner(System.in);
-    static TextualReader reader = new TextualReader(scanner);
+    static final Scanner scanner = new Scanner(System.in);
+    static final TextualReader reader = new TextualReader(scanner);
 
     public static void main(String[] args) throws Exception {
         // Silence Ormlite logging

--- a/src/main/java/interface_adapters/tui/TextualReader.java
+++ b/src/main/java/interface_adapters/tui/TextualReader.java
@@ -1,8 +1,5 @@
 package interface_adapters.tui;
 
-import entity.Recipe;
-import usecase.RecipeManager;
-
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/src/main/java/interface_adapters/tui/controllers/RecipeSearcherOperation.java
+++ b/src/main/java/interface_adapters/tui/controllers/RecipeSearcherOperation.java
@@ -13,18 +13,18 @@ import java.util.List;
 /**
  * An operation for running the recipe recommender use-case.
  */
-public class RecipeSearcherOperation<T extends Preparation> implements TextualOperation {
+public class RecipeSearcherOperation implements TextualOperation {
 
     private final TextualReader reader;
-    private final RecipeSearcher<T> recipeSearcher;
+    private final RecipeSearcher recipeSearcher;
 
     private final List<TextualOperation> operations = List.of(
-            new RecipeSearchIngredientProvider(),
-            new RecipeSearchToolProvider(),
-            new RecipeSearchTagProvider()
+            new RecipeIngredientSearcher(),
+            new RecipeToolSearcher(),
+            new RecipeTagSearcher()
     );
 
-    public RecipeSearcherOperation(TextualReader reader, RecipeSearcher<T> recipeSearcher) {
+    public RecipeSearcherOperation(TextualReader reader, RecipeSearcher recipeSearcher) {
         this.reader = reader;
         this.recipeSearcher = recipeSearcher;
 
@@ -45,7 +45,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
         return "recipe searcher";
     }
 
-    private void finishSearch(List<T> searchList) {
+    private void finishSearch(List<PreparationItem> searchList) {
         List<Recipe> recipes = recipeSearcher.searchRecipe(searchList);
         StringBuilder output = new StringBuilder();
         for (Recipe recipe : recipes) {
@@ -57,7 +57,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
         Colour.info("Here is the list of recipes: \n%s\n", output.toString());
     }
 
-    private class RecipeSearchIngredientProvider implements TextualOperation {
+    private class RecipeIngredientSearcher implements TextualOperation {
         @Override
         public String getCode() {
             return "ingredient search";
@@ -70,7 +70,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
 
         @Override
         public void run() {
-            List<T> searchList = new ArrayList<>();
+            List<PreparationItem> searchList = new ArrayList<>();
 
             while (true) {
                 String name = reader.getInput("Ingredient %d (type %s to search):",
@@ -79,16 +79,15 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
                 if (name.equals("start")) {
                     break;
                 } else if (ingredient != null) {
-                    searchList.add((T) ingredient);
+                    searchList.add(ingredient);
                 }
             }
 
             finishSearch(searchList);
         }
-
     }
 
-    private class RecipeSearchToolProvider implements TextualOperation {
+    private class RecipeToolSearcher implements TextualOperation {
         @Override
         public String getCode() {
             return "tool search";
@@ -101,7 +100,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
 
         @Override
         public void run() {
-            List<T> searchList = new ArrayList<>();
+            List<PreparationItem> searchList = new ArrayList<>();
 
             while (true) {
                 String name = reader.getInput("Tool %d (type %s to search):",
@@ -110,7 +109,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
                 if (name.equals("start")) {
                     break;
                 } else if (tool != null) {
-                    searchList.add((T) tool);
+                    searchList.add(tool);
                 }
             }
 
@@ -118,7 +117,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
         }
     }
 
-    private class RecipeSearchTagProvider implements TextualOperation {
+    private class RecipeTagSearcher implements TextualOperation {
         @Override
         public String getCode() {
             return "tag search";
@@ -131,7 +130,7 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
 
         @Override
         public void run() {
-            List<T> searchList = new ArrayList<>();
+            List<PreparationItem> searchList = new ArrayList<>();
 
             while (true) {
                 String name = reader.getInput("Tag %d (type %s to search):",
@@ -140,13 +139,11 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
                 if (name.equals("start")) {
                     break;
                 } else if (tag != null) {
-                    searchList.add((T) tag);
+                    searchList.add(tag);
                 }
             }
 
             finishSearch(searchList);
         }
     }
-
-
 }

--- a/src/main/java/interface_adapters/tui/controllers/RecipeSearcherOperation.java
+++ b/src/main/java/interface_adapters/tui/controllers/RecipeSearcherOperation.java
@@ -47,14 +47,14 @@ public class RecipeSearcherOperation<T extends Preparation> implements TextualOp
 
     private void finishSearch(List<T> searchList) {
         List<Recipe> recipes = recipeSearcher.searchRecipe(searchList);
-        String output = "";
+        StringBuilder output = new StringBuilder();
         for (Recipe recipe : recipes) {
-            output = output + recipe.getName() + ", ";
+            output.append(recipe.getName()).append(", ");
         }
-        if (output.trim().endsWith(",")) {
-            output = output.substring(0, output.trim().length() - 1);
+        if (output.toString().trim().endsWith(",")) {
+            output = new StringBuilder(output.substring(0, output.toString().trim().length() - 1));
         }
-        Colour.info("Here is the list of recipes: \n%s\n", output);
+        Colour.info("Here is the list of recipes: \n%s\n", output.toString());
     }
 
     private class RecipeSearchIngredientProvider implements TextualOperation {

--- a/src/main/java/usecase/RecipeManager.java
+++ b/src/main/java/usecase/RecipeManager.java
@@ -72,6 +72,7 @@ public class RecipeManager {
      * @param recipe The recipe to attach tags to
      * @param tags   The tags to attach to the recipe
      */
+    @SuppressWarnings("UnusedReturnValue")
     public List<RecipeTag> createRecipeTags(Recipe recipe, List<Tag> tags) {
         Dao<Tag, String> tagsDao = database.getDao(Tag.class);
         Dao<RecipeTag, Integer> recipeTagsDao = database.getDao(RecipeTag.class);
@@ -99,6 +100,7 @@ public class RecipeManager {
      * @param recipe The recipe to attach tools to
      * @param tools  The tools to attach to the recipe
      */
+    @SuppressWarnings("UnusedReturnValue")
     public List<RecipeTool> createRecipeTools(Recipe recipe, List<Tool> tools) {
         Dao<Tool, String> toolsDao = database.getDao(Tool.class);
         Dao<RecipeTool, Integer> recipeToolsDao = database.getDao(RecipeTool.class);

--- a/src/main/java/usecase/RecipeTextConverter.java
+++ b/src/main/java/usecase/RecipeTextConverter.java
@@ -1,4 +1,0 @@
-package usecase;
-
-public class RecipeTextConverter {
-}

--- a/src/test/java/entity/StepTest.java
+++ b/src/test/java/entity/StepTest.java
@@ -1,7 +1,6 @@
 package entity;
 
 import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.table.TableUtils;
 import database.Database;
 import database.InMemoryDatabase;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/entity/ToolTest.java
+++ b/src/test/java/entity/ToolTest.java
@@ -4,7 +4,6 @@ import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.stmt.PreparedQuery;
 import com.j256.ormlite.stmt.QueryBuilder;
 import com.j256.ormlite.stmt.SelectArg;
-import com.j256.ormlite.table.TableUtils;
 import database.Database;
 import database.InMemoryDatabase;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/usecase/RecipeDataConverterTest.java
+++ b/src/test/java/usecase/RecipeDataConverterTest.java
@@ -30,7 +30,7 @@ public class RecipeDataConverterTest {
         Step step2 = new Step("let D be the diameter of A", 2, recipe);
         Step step3 = new Step("pi = C/D", 3, recipe);
 
-        Note tauism = new Note("apple tau might be twice as tasty", recipe);
+        Note tau = new Note("apple tau might be twice as tasty", recipe);
         Note iFruit = new Note("make sure the apple is a fruit, not a computer", recipe);
 
         db.getDao(Recipe.class).create(recipe);
@@ -41,7 +41,7 @@ public class RecipeDataConverterTest {
         db.getDao(Tool.class).create(measuringTape);
         db.getDao(RecipeTool.class).create(recipeMeasuringTape);
         db.getDao(Step.class).create(List.of(step0, step1, step2, step3));
-        db.getDao(Note.class).create(List.of(tauism, iFruit));
+        db.getDao(Note.class).create(List.of(tau, iFruit));
 
         RecipeDataConverter converter = new RecipeDataConverter(db);
         RecipeData data = converter.exportRecipe(recipe);
@@ -81,7 +81,7 @@ public class RecipeDataConverterTest {
         Step step2 = new Step("let D be the diameter of A", 2, recipe);
         Step step3 = new Step("pi = C/D", 3, recipe);
 
-        Note tauism = new Note("apple tau might be twice as tasty", recipe);
+        Note tau = new Note("apple tau might be twice as tasty", recipe);
         Note iFruit = new Note("make sure the apple is a fruit, not a computer", recipe);
 
         RecipeDataConverter converter = new RecipeDataConverter(db);
@@ -91,7 +91,7 @@ public class RecipeDataConverterTest {
                 List.of(recipeRound),
                 List.of(recipeMeasuringTape),
                 List.of(step0, step1, step2, step3),
-                List.of(tauism, iFruit)
+                List.of(tau, iFruit)
         );
         converter.importRecipe(data);
 

--- a/src/test/java/usecase/RecipeSearcherTest.java
+++ b/src/test/java/usecase/RecipeSearcherTest.java
@@ -39,7 +39,7 @@ public class RecipeSearcherTest {
 
 
     @Test
-    public void SearchRecipeTestOneIngredient() throws SQLException {
+    public void SearchRecipeTestOneIngredient() {
         Recipe pie = new Recipe("Pie", 3, 120);
         Recipe tomatoSpaghetti = new Recipe("Tomato Spaghetti", 2, 20);
         Recipe steak = new Recipe("Steak", 1, 15);
@@ -68,7 +68,7 @@ public class RecipeSearcherTest {
     }
 
     @Test
-    public void SearchRecipeTestOneTool() throws SQLException {
+    public void SearchRecipeTestOneTool() {
         Recipe pie = new Recipe("Pie", 3, 120);
         Recipe tomatoSpaghetti = new Recipe("Tomato Spaghetti", 2, 20);
         Recipe steak = new Recipe("Steak", 1, 15);
@@ -97,7 +97,7 @@ public class RecipeSearcherTest {
     }
 
     @Test
-    public void SearchRecipeTestOneTag() throws SQLException {
+    public void SearchRecipeTestOneTag() {
         Recipe pie = new Recipe("Pie", 3, 120);
         Recipe tomatoSpaghetti = new Recipe("Tomato Spaghetti", 2, 20);
         Recipe steak = new Recipe("Steak", 1, 15);
@@ -126,7 +126,7 @@ public class RecipeSearcherTest {
     }
 
     @Test
-    public void SearchRecipeTestManyRecipes() throws SQLException {
+    public void SearchRecipeTestManyRecipes() {
         Recipe pie = new Recipe("Pie", 3, 120);
         Recipe tomatoSpaghetti = new Recipe("Tomato Spaghetti", 2, 20);
         Recipe steak = new Recipe("Steak", 1, 15);
@@ -166,7 +166,7 @@ public class RecipeSearcherTest {
     }
 
     @Test
-    public void SearchRecipeTestManyIngredients() throws SQLException {
+    public void SearchRecipeTestManyIngredients() {
         Recipe pie = new Recipe("Pie", 3, 120);
         Recipe tomatoSpaghetti = new Recipe("Tomato Spaghetti", 2, 20);
         Recipe steak = new Recipe("Steak", 1, 15);

--- a/src/test/java/usecase/RecipeSearcherTest.java
+++ b/src/test/java/usecase/RecipeSearcherTest.java
@@ -15,9 +15,7 @@ import java.util.List;
 public class RecipeSearcherTest {
 
     private RecipeManager manager;
-    private RecipeSearcher<Ingredient> ingredientSearcher;
-    private RecipeSearcher<Tool> toolSearcher;
-    private RecipeSearcher<Tag> tagSearcher;
+    private RecipeSearcher searcher;
     private Dao<RecipeIngredient, Integer> recipeIngredients;
 
     private Dao<RecipeTool, Integer> recipeTools;
@@ -29,9 +27,7 @@ public class RecipeSearcherTest {
     public void Setup() throws SQLException {
         Database database = new InMemoryDatabase();
         manager = new RecipeManager(database);
-        ingredientSearcher = new RecipeSearcher<>(database);
-        toolSearcher = new RecipeSearcher<>(database);
-        tagSearcher = new RecipeSearcher<>(database);
+        searcher = new RecipeSearcher(database);
         recipeIngredients = database.getDao(RecipeIngredient.class);
         recipeTools = database.getDao(RecipeTool.class);
         recipeTags = database.getDao(RecipeTag.class);
@@ -57,10 +53,10 @@ public class RecipeSearcherTest {
             throw new RuntimeException(e);
         }
 
-        List<Ingredient> ingredientList = new ArrayList<>();
+        List<PreparationItem> ingredientList = new ArrayList<>();
         ingredientList.add(beefSirloin);
 
-        List<Recipe> returnRecipe = ingredientSearcher.searchRecipe(ingredientList);
+        List<Recipe> returnRecipe = searcher.searchRecipe(ingredientList);
         List<Recipe> expected = new ArrayList<>();
         expected.add(steak);
 
@@ -86,10 +82,10 @@ public class RecipeSearcherTest {
             throw new RuntimeException(e);
         }
 
-        List<Tool> toolList = new ArrayList<>();
+        List<PreparationItem> toolList = new ArrayList<>();
         toolList.add(pan);
 
-        List<Recipe> returnRecipe = toolSearcher.searchRecipe(toolList);
+        List<Recipe> returnRecipe = searcher.searchRecipe(toolList);
         List<Recipe> expected = new ArrayList<>();
         expected.add(steak);
 
@@ -115,10 +111,10 @@ public class RecipeSearcherTest {
             throw new RuntimeException(e);
         }
 
-        List<Tag> tagList = new ArrayList<>();
+        List<PreparationItem> tagList = new ArrayList<>();
         tagList.add(beef);
 
-        List<Recipe> returnRecipe = tagSearcher.searchRecipe(tagList);
+        List<Recipe> returnRecipe = searcher.searchRecipe(tagList);
         List<Recipe> expected = new ArrayList<>();
         expected.add(steak);
 
@@ -153,10 +149,10 @@ public class RecipeSearcherTest {
             throw new RuntimeException(e);
         }
 
-        List<Ingredient> ingredientList = new ArrayList<>();
+        List<PreparationItem> ingredientList = new ArrayList<>();
         ingredientList.add(tomato);
 
-        List<Recipe> returnRecipe = ingredientSearcher.searchRecipe(ingredientList);
+        List<Recipe> returnRecipe = searcher.searchRecipe(ingredientList);
         List<Recipe> expected = new ArrayList<>();
         expected.add(tomatoSpaghetti);
         expected.add(tomatoJuice);
@@ -196,11 +192,11 @@ public class RecipeSearcherTest {
             throw new RuntimeException(e);
         }
 
-        List<Ingredient> ingredientList = new ArrayList<>();
+        List<PreparationItem> ingredientList = new ArrayList<>();
         ingredientList.add(tomato);
         ingredientList.add(pasta);
 
-        List<Recipe> returnRecipe = ingredientSearcher.searchRecipe(ingredientList);
+        List<Recipe> returnRecipe = searcher.searchRecipe(ingredientList);
         List<Recipe> expected = new ArrayList<>();
         expected.add(tomatoSpaghetti);
 


### PR DESCRIPTION
This PR resolves (as far as I can tell) all warnings in project files in IntelliJ. Most issues were unused getters and setters, which have had their warnings suppressed because they're likely to be used in future development. Resolving the warnings also required a restructuring of the recipe searcher.

Closes #39 